### PR TITLE
Added cvStartWindowThread call for debug window

### DIFF
--- a/src/linemod_detect.cpp
+++ b/src/linemod_detect.cpp
@@ -192,6 +192,10 @@ struct Detector: public object_recognition_core::db::bases::ModelReaderBase {
     configure(const tendrils& params, const tendrils& inputs, const tendrils& outputs)
     {
       configure_impl();
+
+#if LINEMOD_VIZ_IMG
+      cvStartWindowThread();
+#endif
     }
 
     /**


### PR DESCRIPTION
On my machine, the debugging visualization window wasn't working properly most of the time. It seems as if this is caused by OS events going unhandled.

Adding a call to cvStartWindowThread() solves these issues.